### PR TITLE
unix OS compatibility, overflow handling for narrowband, image rotation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Images to audio files with corresponding spectrograms encoder.
 ## Usage
 
 ```
-usage: spectrology.py [-h] [-o OUTPUT] [-b BOTTOM] [-t TOP] [-p PIXELS]
+usage: spectrology.py [-h] [-r] [-o OUTPUT] [-b BOTTOM] [-t TOP] [-p PIXELS]
                       [-s SAMPLING]
                       INPUT
 
@@ -13,6 +13,7 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  -r, --rotate          Rotate image 90 degrees.
   -o OUTPUT, --output OUTPUT
                         Name of the output wav file. Default value: out.wav).
   -b BOTTOM, --bottom BOTTOM

--- a/spectrology.py
+++ b/spectrology.py
@@ -73,6 +73,11 @@ def convert(inpt, output, minfreq, maxfreq, pxs, wavrate):
                     data[i + x * fpx] += j[i]
                 except(IndexError):
                     data.insert(i + x * fpx, j[i])
+                except(OverflowError):
+                    if j[i] > 0:
+                      data[i + x * fpx] = 32767
+                    else:
+                      data[i + x * fpx] = -32768
 
         sys.stdout.write("Conversion progress: %d%%   \r" % (float(x) / img.size[0]*100) )
         sys.stdout.flush()

--- a/spectrology.py
+++ b/spectrology.py
@@ -14,6 +14,7 @@ import wave, math, array, argparse, sys, timeit
 def parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("INPUT", help="Name of the image to be convected.")
+    parser.add_argument("-r", "--rotate", help="Rotate image 90 degrees.", action='store_true')
     parser.add_argument("-o", "--output", help="Name of the output wav file. Default value: out.wav).")
     parser.add_argument("-b", "--bottom", help="Bottom frequency range. Default value: 200.", type=int)
     parser.add_argument("-t", "--top", help="Top frequency range. Default value: 20000.", type=int)
@@ -26,6 +27,7 @@ def parser():
     wavrate = 44100
     pxs     = 30
     output  = "out.wav"
+    rotate  = False
 
     if args.output:
         output = args.output
@@ -37,16 +39,21 @@ def parser():
         pxs = args.pixels
     if args.sampling:
         wavrate = args.sampling
+    if args.rotate:
+        rotate = True
 
     print('Input file: %s.' % args.INPUT)
     print('Frequency range: %d - %d.' % (minfreq, maxfreq))
     print('Pixels per second: %d.' % pxs)
     print('Sampling rate: %d.' % wavrate)
+    print('Rotate Image: %s.' % ('yes' if rotate else 'no'))
 
-    return (args.INPUT, output, minfreq, maxfreq, pxs, wavrate)
+    return (args.INPUT, output, minfreq, maxfreq, pxs, wavrate, rotate)
 
-def convert(inpt, output, minfreq, maxfreq, pxs, wavrate):
+def convert(inpt, output, minfreq, maxfreq, pxs, wavrate, rotate):
     img = Image.open(inpt).convert('RGB')
+    if rotate:
+      img = img.rotate(90)
 
     output = wave.open(output, 'w')
     output.setparams((1, 2, wavrate, 0, 'NONE', 'not compressed'))

--- a/spectrology.py
+++ b/spectrology.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 '''
 Spectrology
 This script is able to encode an image into audio file whose spectrogram represents input image.

--- a/spectrology.py
+++ b/spectrology.py
@@ -51,7 +51,7 @@ def parser():
     return (args.INPUT, output, minfreq, maxfreq, pxs, wavrate, rotate)
 
 def convert(inpt, output, minfreq, maxfreq, pxs, wavrate, rotate):
-    img = Image.open(inpt).convert('RGB')
+    img = Image.open(inpt).convert('L')
     if rotate:
       img = img.rotate(90)
 
@@ -70,7 +70,7 @@ def convert(inpt, output, minfreq, maxfreq, pxs, wavrate, rotate):
         row = []
         for y in range(img.size[1]):
             yinv = img.size[1] - y - 1
-            amp = color( img.getpixel((x,y)) )
+            amp = img.getpixel((x,y))
             if (amp > 0):
                 row.append( genwave(yinv * interval + minfreq, amp, fpx, wavrate) )
 
@@ -96,9 +96,6 @@ def convert(inpt, output, minfreq, maxfreq, pxs, wavrate, rotate):
 
     print("Conversion progress: 100%")
     print("Success. Completed in %d seconds." % int(tms-tm))
-
-def color(rgb):
-    return (rgb[0] + rgb[1] + rgb[2])/3
 
 def genwave(frequency, amplitude, samples, samplerate):
     cycles = samples * frequency / samplerate

--- a/spectrology.py
+++ b/spectrology.py
@@ -8,13 +8,14 @@ License: MIT
 Website: https://github.com/solusipse/spectrology
 '''
 
-from PIL import Image
+from PIL import Image, ImageOps
 import wave, math, array, argparse, sys, timeit
 
 def parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("INPUT", help="Name of the image to be convected.")
-    parser.add_argument("-r", "--rotate", help="Rotate image 90 degrees.", action='store_true')
+    parser.add_argument("-r", "--rotate", help="Rotate image 90 degrees for waterfall spectrographs.", action='store_true')
+    parser.add_argument("-i", "--invert", help="Invert image colors.", action='store_true')
     parser.add_argument("-o", "--output", help="Name of the output wav file. Default value: out.wav).")
     parser.add_argument("-b", "--bottom", help="Bottom frequency range. Default value: 200.", type=int)
     parser.add_argument("-t", "--top", help="Top frequency range. Default value: 20000.", type=int)
@@ -28,6 +29,7 @@ def parser():
     pxs     = 30
     output  = "out.wav"
     rotate  = False
+    invert  = False
 
     if args.output:
         output = args.output
@@ -41,6 +43,8 @@ def parser():
         wavrate = args.sampling
     if args.rotate:
         rotate = True
+    if args.invert:
+        invert = True
 
     print('Input file: %s.' % args.INPUT)
     print('Frequency range: %d - %d.' % (minfreq, maxfreq))
@@ -48,12 +52,18 @@ def parser():
     print('Sampling rate: %d.' % wavrate)
     print('Rotate Image: %s.' % ('yes' if rotate else 'no'))
 
-    return (args.INPUT, output, minfreq, maxfreq, pxs, wavrate, rotate)
+    return (args.INPUT, output, minfreq, maxfreq, pxs, wavrate, rotate, invert)
 
-def convert(inpt, output, minfreq, maxfreq, pxs, wavrate, rotate):
+def convert(inpt, output, minfreq, maxfreq, pxs, wavrate, rotate, invert):
     img = Image.open(inpt).convert('L')
+
+    # rotate image if requested
     if rotate:
       img = img.rotate(90)
+
+    # invert image if requested
+    if invert:
+      img = ImageOps.invert(img)
 
     output = wave.open(output, 'w')
     output.setparams((1, 2, wavrate, 0, 'NONE', 'not compressed'))


### PR DESCRIPTION
The first line of a unix script needs to contain a directive of what interpreter run it instead of just the filename extension used by Microsoft operating systems.