### PR TITLE
Use integer division

### DIFF
--- a/spectrology.py
+++ b/spectrology.py
@@ -71,7 +71,7 @@ def convert(inpt, output, minfreq, maxfreq, pxs, wavrate, rotate, invert):
     freqrange = maxfreq - minfreq
     interval = freqrange / img.size[1]
 
-    fpx = wavrate / pxs
+    fpx = wavrate // pxs
     data = array.array('h')
 
     tm = timeit.default_timer()


### PR DESCRIPTION
This fixes `TypeError` on Python 3.

```
Traceback (most recent call last):
  File "spectrology.py", line 120, in <module>
    convert(*inpt)
  File "spectrology.py", line 85, in convert
    row.append( genwave(yinv * interval + minfreq, amp, fpx, wavrate) )
  File "spectrology.py", line 113, in genwave
    for i in range(samples):
TypeError: 'float' object cannot be interpreted as an integer
```