### PR TITLE
replace tostring() with tobytes() to fix python3 error

### DIFF
--- a/spectrology.py
+++ b/spectrology.py
@@ -99,7 +99,7 @@ def convert(inpt, output, minfreq, maxfreq, pxs, wavrate, rotate, invert):
         sys.stdout.write("Conversion progress: %d%%   \r" % (float(x) / img.size[0]*100) )
         sys.stdout.flush()
 
-    output.writeframes(data)
+    output.writeframes(data.tobytes())
     output.close()
 
     tms = timeit.default_timer()

--- a/spectrology.py
+++ b/spectrology.py
@@ -99,7 +99,7 @@ def convert(inpt, output, minfreq, maxfreq, pxs, wavrate, rotate, invert):
         sys.stdout.write("Conversion progress: %d%%   \r" % (float(x) / img.size[0]*100) )
         sys.stdout.flush()
 
-    output.writeframes(data.tostring())
+    output.writeframes(data)
     output.close()
 
     tms = timeit.default_timer()


### PR DESCRIPTION
When running spectrology.py with python3, you get this error: 
```console
Traceback (most recent call last):
  File "/spectrology.py", line 120, in <module>
    convert(*inpt)
  File "spectrology.py", line 102, in convert
    output.writeframes(data.tostring())
AttributeError: 'array.array' object has no attribute 'tostring'
```
According to the [docs](https://docs.python.org/3/library/array.html) for `array`, `tostring()` has been renamed to `tobytes()` since version 3.2. Replacing `tostring()` with `tobytes()` in `output.writeframes(data.tostring())` fixes the error and everything still works as it should.