### PR TITLE
Update spectrology.py

### DIFF
--- a/spectrology.py
+++ b/spectrology.py
@@ -99,7 +99,7 @@ def convert(inpt, output, minfreq, maxfreq, pxs, wavrate, rotate, invert):
         sys.stdout.write("Conversion progress: %d%%   \r" % (float(x) / img.size[0]*100) )
         sys.stdout.flush()
 
-    output.writeframes(data.tostring())
+    output.writeframes(data.tobytes())
     output.close()
 
     tms = timeit.default_timer()


### PR DESCRIPTION
Fix audio export error by replacing deprecated tostring() method with tobytes() in spectrology.py. Ensures compatibility with Python 3.2+.